### PR TITLE
Feature/redirect unit test logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,14 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
+				<configuration>
+					<systemProperties>
+						<property>
+							<name>java.util.logging.config.file</name>
+							<value>src/test/resources/logging.properties</value>
+						</property>
+					</systemProperties>
+				</configuration>
 			</plugin>
 
 			<!--

--- a/src/main/java/org/reactome/release/dataexport/DataExporterStep.java
+++ b/src/main/java/org/reactome/release/dataexport/DataExporterStep.java
@@ -18,7 +18,7 @@ import java.util.Properties;
  * @author jweiser
  */
 public class DataExporterStep extends ReleaseStep {
-	private static final Logger logger = LogManager.getLogger();
+	private static final Logger logger = LogManager.getLogger("mainLog");
 
 	/**
 	 * Queries the Reactome Neo4J Graph Database for the current release version and

--- a/src/main/java/org/reactome/release/dataexport/EuropePMC.java
+++ b/src/main/java/org/reactome/release/dataexport/EuropePMC.java
@@ -24,7 +24,7 @@ import static org.reactome.release.dataexport.DataExportUtilities.*;
  * @author jweiser
  */
 public class EuropePMC {
-	private static final Logger logger = LogManager.getLogger();
+	private static final Logger logger = LogManager.getLogger("mainLog");
 	private static final String rootTag = "links";
 	private static final int reactomeProviderID = 1925;
 

--- a/src/main/java/org/reactome/release/dataexport/NCBIEntry.java
+++ b/src/main/java/org/reactome/release/dataexport/NCBIEntry.java
@@ -17,7 +17,7 @@ import java.util.*;
  * @author jweiser
  */
 public class NCBIEntry implements Comparable<NCBIEntry> {
-	private static final Logger logger = LogManager.getLogger();
+	private static final Logger logger = LogManager.getLogger("mainLog");
 
 	private static int linkId = 1;
 

--- a/src/main/java/org/reactome/release/dataexport/NCBIGene.java
+++ b/src/main/java/org/reactome/release/dataexport/NCBIGene.java
@@ -22,7 +22,7 @@ import static org.reactome.release.dataexport.DataExportUtilities.*;
  * @author jweiser
  */
 public class NCBIGene {
-	private static final Logger logger = LogManager.getLogger();
+	private static final Logger logger = LogManager.getLogger("mainLog");
 	private static final Logger ncbiGeneLogger = LogManager.getLogger("ncbiGeneLog");
 
 	private static final String rootTag = "LinkSet";

--- a/src/main/java/org/reactome/release/dataexport/NCBIProtein.java
+++ b/src/main/java/org/reactome/release/dataexport/NCBIProtein.java
@@ -22,7 +22,7 @@ import static org.reactome.release.dataexport.DataExportUtilities.deleteAndCreat
  * @author jweiser
  */
 public class NCBIProtein {
-	private static final Logger logger = LogManager.getLogger();
+	private static final Logger logger = LogManager.getLogger("mainLog");
 
 	private List<NCBIEntry> ncbiEntries;
 	private String outputDir;

--- a/src/main/java/org/reactome/release/dataexport/PathwayHierarchyUtilities.java
+++ b/src/main/java/org/reactome/release/dataexport/PathwayHierarchyUtilities.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
  * @author jweiser
  */
 public class PathwayHierarchyUtilities {
-	private static final Logger logger = LogManager.getLogger();
+	private static final Logger logger = LogManager.getLogger("mainLog");
 
 	private static Map<Session, Map<Long, Set<Long>>> rleToPathwayIdCache = new HashMap<>();
 	private static Map<Session, Map<Long, Set<Long>>> pathwayHierarchyCache = new HashMap<>();

--- a/src/main/java/org/reactome/release/dataexport/ReactomeEvent.java
+++ b/src/main/java/org/reactome/release/dataexport/ReactomeEvent.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 public class ReactomeEvent {
 	private static Map<String, String> namePatternToReplacement;
 	private static Map<Session, Map<Long, ReactomeEvent>> eventCache = new HashMap<>();
-	private static Logger logger = LogManager.getLogger();
+	private static Logger logger = LogManager.getLogger("mainLog");
 
 	private long dbId;
 	private String name;

--- a/src/main/java/org/reactome/release/dataexport/UCSC.java
+++ b/src/main/java/org/reactome/release/dataexport/UCSC.java
@@ -21,7 +21,7 @@ import static org.reactome.release.dataexport.DataExportUtilities.deleteAndCreat
  * @author jweiser
  */
 public class UCSC {
-	private static final Logger logger = LogManager.getLogger();
+	private static final Logger logger = LogManager.getLogger("mainLog");
 
 	private Set<UniProtReactomeEntry> ucscUniProtReactomeEntries;
 	private int version;

--- a/src/main/java/org/reactome/release/dataexport/UniProtReactomeEntry.java
+++ b/src/main/java/org/reactome/release/dataexport/UniProtReactomeEntry.java
@@ -44,7 +44,7 @@ public class UniProtReactomeEntry implements Comparable<UniProtReactomeEntry> {
 	private static Map<Session, Map<UniProtReactomeEntry, Set<Long>>>
 		uniprotReactomeEntryToReactionLikeEventIdCache = new HashMap<>();
 
-	private static Logger logger = LogManager.getLogger();
+	private static Logger logger = LogManager.getLogger("mainLog");
 
 	private long dbId;
 	private String accession;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
 			<PatternLayout pattern="${logPattern}" />
 		</Console>
 		<RollingFile
-			name="LogFile"
+			name="mainLogFile"
 			fileName="${baseDir}/Main-${date:MM-dd-yyyy_HH.mm.ss}.log"
 			filePattern="${baseDir}/Main-%d{MM-dd-yyyy_HH.mm.ss}.log"
 		>
@@ -48,8 +48,10 @@
 	<Loggers>
 		<Root level="debug">
 			<AppenderRef ref="Console" level="debug"/>
-			<AppenderRef ref="LogFile" level="info"/>
 		</Root>
+		<Logger name="mainLog" level="debug" additivity="false">
+			<AppenderRef ref="mainLogFile"/>
+		</Logger>
 		<Logger name="warningsLog" level="warn" additivity="false">
 			<AppenderRef ref="warningsLogFile"/>
 		</Logger>

--- a/src/test/java/org/reactome/release/dataexport/DummyGraphDBServer.java
+++ b/src/test/java/org/reactome/release/dataexport/DummyGraphDBServer.java
@@ -1,6 +1,9 @@
 package org.reactome.release.dataexport;
 
+import java.util.logging.Level;
 import org.junit.jupiter.api.TestInstance;
+import org.neo4j.driver.internal.logging.JULogging;
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.harness.ServerControls;
@@ -28,7 +31,10 @@ public class DummyGraphDBServer {
 
 	public void initializeNeo4j() {
 		ServerControls embeddedDatabaseServer = TestServerBuilders.newInProcessBuilder().newServer();
-		this.session = GraphDatabase.driver(embeddedDatabaseServer.boltURI()).session();
+		this.session = GraphDatabase.driver(
+			embeddedDatabaseServer.boltURI(),
+			Config.build().withLogging(new JULogging(Level.OFF)).toConfig()
+		).session();
 	}
 
 	public void populateDummyGraphDB() {

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -5,9 +5,9 @@
 			<PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
 		</Console>
 	</Appenders>
-	<Logger>
+	<Loggers>
 		<Root level="OFF">
 			<AppenderRef ref="Console" />
 		</Root>
-	</Logger>
+	</Loggers>
 </Configuration>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info">
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT">
+			<PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+		</Console>
+	</Appenders>
+	<Logger>
+		<Root level="OFF">
+			<AppenderRef ref="Console" />
+		</Root>
+	</Logger>
+</Configuration>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,13 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="info">
+	<Properties>
+		<Property name="baseDir">src/test/resources/logs</Property>
+		<Property name="logPattern">%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %l - %msg%n</Property>
+	</Properties>
 	<Appenders>
 		<Console name="Console" target="SYSTEM_OUT">
-			<PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+			<PatternLayout pattern="${logPattern}" />
 		</Console>
+
+		<RollingFile
+			name="mainLogFile"
+			fileName="${baseDir}/Main-${date:MM-dd-yyyy_HH.mm.ss}.log"
+			filePattern="${baseDir}/Main-%d{MM-dd-yyyy_HH.mm.ss}.log"
+		>
+			<PatternLayout>
+				<Pattern>${logPattern}</Pattern>
+			</PatternLayout>
+			<Policies>
+				<OnStartupTriggeringPolicy />
+			</Policies>
+		</RollingFile>
+		<RollingFile
+			name="warningsLogFile"
+			fileName="${baseDir}/Main-${date:MM-dd-yyyy_HH.mm.ss}.err"
+			filePattern="${baseDir}/Main-%d{MM-dd-yyyy_HH.mm.ss}.err"
+		>
+			<PatternLayout>
+				<Pattern>${logPattern}</Pattern>
+			</PatternLayout>
+			<Policies>
+				<OnStartupTriggeringPolicy />
+			</Policies>
+		</RollingFile>
+		<RollingFile
+			name="ncbiGeneLogFile"
+			fileName="${baseDir}/NCBIGene-${date:MM-dd-yyyy_HH.mm.ss}.log"
+			filePattern="${baseDir}/NCBIGene-%d{MM-dd-yyyy_HH.mm.ss}.log"
+		>
+			<PatternLayout>
+				<Pattern>${logPattern}</Pattern>
+			</PatternLayout>
+			<Policies>
+				<OnStartupTriggeringPolicy />
+			</Policies>
+		</RollingFile>
 	</Appenders>
 	<Loggers>
-		<Root level="OFF">
-			<AppenderRef ref="Console" />
+		<Root level="debug">
+			<AppenderRef ref="Console" level="debug"/>
 		</Root>
+		<Logger name="mainLog" level="info" additivity="false">
+			<AppenderRef ref="mainLogFile"/>
+		</Logger>
+		<Logger name="warningsLog" level="warn" additivity="false">
+			<AppenderRef ref="warningsLogFile"/>
+		</Logger>
+		<Logger name="ncbiGeneLog" level="info" additivity="false">
+			<AppenderRef ref="ncbiGeneLogFile"/>
+		</Logger>
 	</Loggers>
 </Configuration>

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+java.util.logging.ConsoleHandler.level=OFF

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,1 +1,1 @@
-java.util.logging.ConsoleHandler.level=OFF
+com.sun.jersey.server.impl.application.WebApplicationImpl.level = OFF

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,1 +1,4 @@
-com.sun.jersey.server.impl.application.WebApplicationImpl.level = OFF
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = INFO
+
+com.sun.jersey.server.impl.application.WebApplicationImpl.level = WARNING


### PR DESCRIPTION
Excessive log output was being produced while running unit tests.  This PR adds configuration that turns off logging for tests only.  Running this locally, "mvn test" produces quieter output for successful tests but still outputs when, and why, a test fails.